### PR TITLE
HB-4935: Simplify use of unknown errors in adapters

### DIFF
--- a/Source/ReferenceAdapterFullscreenAd.swift
+++ b/Source/ReferenceAdapterFullscreenAd.swift
@@ -71,7 +71,7 @@ extension ReferenceAdapterFullscreenAd: ReferenceFullscreenAdDelegate {
     }
     
     func onAdShowFailed(_ referenceError: Error?) {
-        let error = error(.showFailureUnknown, error: referenceError)
+        let error = referenceError ?? self.error(.showFailureUnknown)
         log(.showFailed(error))
         showCompletion?(.failure(error)) ?? log(.showResultIgnored)
         showCompletion = nil


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-4935

Partner errors can now be directly used with `PartnerAdLogEvent` and the completion handlers, which will get auto-wrapped within a `HeliumError` with the appropriate `unknown` code, per the work done in https://github.com/ChartBoost/ios-helium-sdk/pull/882.  Also, partners that supply a code can create an error using the `PartnerAd.partnerError(_code:)` method instead.
