### PR TITLE
HB-5057: import ChartboostMediationSDK instead of HeliumSdk

### DIFF
--- a/Source/ReferenceAdapter.swift
+++ b/Source/ReferenceAdapter.swift
@@ -10,8 +10,8 @@
 //  Created by Vu Chau on 8/22/22.
 //
 
+import ChartboostMediationSDK
 import Foundation
-import HeliumSdk
 import UIKit
 
 /// INTERNAL. FOR DEMO AND TESTING PURPOSES ONLY. DO NOT USE DIRECTLY.

--- a/Source/ReferenceAdapterAd.swift
+++ b/Source/ReferenceAdapterAd.swift
@@ -10,8 +10,8 @@
 //  Created by Daniel Barros on 10/14/22.
 //
 
+import ChartboostMediationSDK
 import Foundation
-import HeliumSdk
 
 /// INTERNAL. FOR DEMO AND TESTING PURPOSES ONLY. DO NOT USE DIRECTLY.
 ///

--- a/Source/ReferenceAdapterBannerAd.swift
+++ b/Source/ReferenceAdapterBannerAd.swift
@@ -10,8 +10,8 @@
 //  Created by Vu Chau on 8/22/22.
 //
 
+import ChartboostMediationSDK
 import Foundation
-import HeliumSdk
 
 /// INTERNAL. FOR DEMO AND TESTING PURPOSES ONLY. DO NOT USE DIRECTLY.
 ///

--- a/Source/ReferenceAdapterFullscreenAd.swift
+++ b/Source/ReferenceAdapterFullscreenAd.swift
@@ -10,8 +10,8 @@
 //  Created by Vu Chau on 8/22/22.
 //
 
+import ChartboostMediationSDK
 import Foundation
-import HeliumSdk
 
 /// INTERNAL. FOR DEMO AND TESTING PURPOSES ONLY. DO NOT USE DIRECTLY.
 ///

--- a/Source/ReferenceSdk/ReferenceBannerAd.swift
+++ b/Source/ReferenceSdk/ReferenceBannerAd.swift
@@ -10,8 +10,8 @@
 //  Created by Vu Chau on 8/22/22.
 //
 
+import ChartboostMediationSDK
 import Foundation
-import HeliumSdk
 import SafariServices
 import UIKit
 import WebKit

--- a/Source/ReferenceSdk/ReferenceFullscreenAd.swift
+++ b/Source/ReferenceSdk/ReferenceFullscreenAd.swift
@@ -10,9 +10,9 @@
 //  Created by Vu Chau on 8/22/22.
 //
 
+import ChartboostMediationSDK
 import Foundation
 import SafariServices
-import HeliumSdk
 
 /// INTERNAL. FOR DEMO AND TESTING PURPOSES ONLY. DO NOT USE DIRECTLY.
 /// A dummy SDK designed to support the reference adapter.


### PR DESCRIPTION
This is a companion PR of https://github.com/ChartBoost/ios-helium-sdk/pull/942.

Discussed with Dani and decided to merge the tedious adapter PR's without code review to speed up the whole rebranding process.