### PR TITLE
HB-5460: Create Release Branch workflow

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -1,0 +1,61 @@
+name: Create Release Branch
+
+on:
+  # Manual trigger from the Github Actions tab
+  workflow_dispatch:
+    inputs:
+      adapter-version:
+        type: string
+        description: 'Adapter version (e.g. \'4.9.2.0.0\')''
+        required: true
+      partner-version:
+        type: string
+        description: 'Partner version (e.g. \'~> 9.2.0\')'
+        required: true
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUBSERVICETOKEN }}
+
+jobs:
+  validate-podspec:
+    runs-on: macos-latest
+    steps:
+      # Check out the repo.
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Validate adapter and partner versions are compatible.
+      - name: Validate Adapter and Partner Version Match
+        run: if [ "$(ruby ./Scripts/validate-adapter-and-partner-versions.rb ${{ inputs.adapter-version }} ${{ inputs.partner-version }})" != "true" ]; then exit 1; fi
+        shell: bash
+
+      # Validate adapter version is well-formed and not already released.
+      - name: Validate Adapter Version
+        run: if [ "$(ruby ./Scripts/validate-new-release-version.rb) ${{ inputs.adapter-version }}" != "true" ]; then exit 1; fi
+        shell: bash
+
+      # Create and checkout branch
+      - name: Create Branch
+        run: git checkout -b "release/${{ github.ref_name }}"
+        shell: bash
+
+      # Update version strings in podspec.
+      - name: Update Version Strings in Podspec
+        run: ruby ./Scripts/update_podspec_versions.rb ${{ inputs.adapter-version }} ${{ inputs.partner-version }})
+        shell: bash
+
+      # Update version string in main adapter class.
+      - name: Update Version String in Partner Adapter Class
+        run: ruby ./Scripts/update_adapter_class_version.rb ${{ inputs.adapter-version }}
+        shell: bash
+
+      # Add new changelog entry for the current adapter version.
+      - name: Add Changelog Entry
+        run: ruby ./Scripts/add-changelog-entry.rb ${{ inputs.adapter-version }} ${{ inputs.partner-version }})
+        shell: bash
+
+      # Commit and push changes.
+      - name: Push Changes
+        if: ${{ steps.changelog_entry.outputs.result == 'added' }}
+        run: git add *.podspec CHANGELOG.md Source/*Adapter.swift && git commit -m '[AUTO-GENERATED] Update version strings and changelog' && git push -u origin "release/${{ github.ref_name }}"
+        shell: bash

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -6,12 +6,17 @@ on:
     inputs:
       adapter-version:
         type: string
-        description: 'Adapter version (e.g. \'4.9.2.0.0\')''
+        description: 'Adapter version (e.g. ''4.9.2.0.0'')'
         required: true
       partner-version:
         type: string
-        description: 'Partner version (e.g. \'~> 9.2.0\')'
+        description: 'Partner version (e.g. ''~> 9.2.0'')'
         required: true
+        default: '~> '
+      tag:
+        type: string
+        description: 'Tag to be used as base for the new branch. If empty, the selected branch is used instead.'
+        required: false
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUBSERVICETOKEN }}
@@ -20,9 +25,18 @@ jobs:
   validate-podspec:
     runs-on: macos-latest
     steps:
-      # Check out the repo.
-      - name: Checkout
+
+      # Check out the repo at the specified branch.
+      - name: Checkout Branch
+        if: ${{ inputs.tag == '' }}
         uses: actions/checkout@v3
+
+      # Check out the repo at the specified tag.
+      - name: Checkout Tag
+        if: ${{ inputs.tag != '' }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.tag }}
 
       # Validate adapter and partner versions are compatible.
       - name: Validate Adapter and Partner Version Match

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -22,7 +22,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUBSERVICETOKEN }}
 
 jobs:
-  validate-podspec:
+  create-release-branch:
     runs-on: macos-latest
     steps:
 
@@ -40,36 +40,35 @@ jobs:
 
       # Validate adapter and partner versions are compatible.
       - name: Validate Adapter and Partner Version Match
-        run: if [ "$(ruby ./Scripts/validate-adapter-and-partner-versions.rb ${{ inputs.adapter-version }} ${{ inputs.partner-version }})" != "true" ]; then exit 1; fi
+        run: if [ "$(ruby ./Scripts/validate-adapter-and-partner-versions.rb '${{ inputs.adapter-version }}' '${{ inputs.partner-version }}')" != "true" ]; then exit 1; fi
         shell: bash
 
       # Validate adapter version is well-formed and not already released.
       - name: Validate Adapter Version
-        run: if [ "$(ruby ./Scripts/validate-new-release-version.rb) ${{ inputs.adapter-version }}" != "true" ]; then exit 1; fi
+        run: if [ "$(ruby ./Scripts/validate-new-release-version.rb '${{ inputs.adapter-version }}')" != "true" ]; then exit 1; fi
         shell: bash
 
       # Create and checkout branch
       - name: Create Branch
-        run: git checkout -b "release/${{ github.ref_name }}"
+        run: git checkout -b "release/${{ inputs.adapter-version }}"
         shell: bash
 
       # Update version strings in podspec.
       - name: Update Version Strings in Podspec
-        run: ruby ./Scripts/update_podspec_versions.rb ${{ inputs.adapter-version }} ${{ inputs.partner-version }})
+        run: ruby ./Scripts/update_podspec_versions.rb "${{ inputs.adapter-version }}" "${{ inputs.partner-version }}"
         shell: bash
 
       # Update version string in main adapter class.
       - name: Update Version String in Partner Adapter Class
-        run: ruby ./Scripts/update_adapter_class_version.rb ${{ inputs.adapter-version }}
+        run: ruby ./Scripts/update_adapter_class_version.rb "${{ inputs.adapter-version }}"
         shell: bash
 
       # Add new changelog entry for the current adapter version.
       - name: Add Changelog Entry
-        run: ruby ./Scripts/add-changelog-entry.rb ${{ inputs.adapter-version }} ${{ inputs.partner-version }})
+        run: ruby ./Scripts/add-changelog-entry.rb "${{ inputs.adapter-version }}" "${{ inputs.partner-version }}"
         shell: bash
 
       # Commit and push changes.
       - name: Push Changes
-        if: ${{ steps.changelog_entry.outputs.result == 'added' }}
-        run: git add *.podspec CHANGELOG.md Source/*Adapter.swift && git commit -m '[AUTO-GENERATED] Update version strings and changelog' && git push -u origin "release/${{ github.ref_name }}"
+        run: git add *.podspec CHANGELOG.md Source/*Adapter.swift && git commit -m '[AUTO-GENERATED] Update version strings and changelog' && git push -u origin "release/${{ inputs.adapter-version }}"
         shell: bash

--- a/Scripts/add-changelog-entry.rb
+++ b/Scripts/add-changelog-entry.rb
@@ -1,21 +1,24 @@
-require_relative 'common'
-
 # Adds a new changelog entry using its current podspec version.
 # Assumes that the partner SDK is the last dependency in the podspec file.
 
-# Obtain the adapter version, partner SDK name, and partner version, from the podspec
-adapter_version = podspec_version()
-partner_sdk, partner_version = podspec_partner_sdk_name_and_version()
+require_relative 'common'
+
+# Parse the version strings from the arguments
+abort "Missing argument. Requires: adapter version string, partner version string." unless ARGV.count == 2
+adapter_version = ARGV[0]
+partner_version = ARGV[1]
+
+# Strip the cocoapods optimistic operation from the partner version if it exists
+partner_version = partner_version.delete_prefix('~> ')
+
+# Obtain the partner SDK name from the podspec
+partner_sdk_name = podspec_partner_sdk_name()
 
 # Read the changelog file
 changelog = read_changelog()
 
-if changelog.include? "### #{adapter_version}"
-  # Skip if entry already exists
-  puts "skipped"
-else
-  # Otherwise add the new entry right before the last one
-  changelog = changelog.sub("###", "### #{adapter_version}\n- This version of the adapters has been certified with #{partner_sdk} #{partner_version}.\n\n###")
+# Add the new entry right before the last one, if the entry does not already exist for this version
+if !changelog.include? "### #{adapter_version}"
+  changelog = changelog.sub("###", "### #{adapter_version}\n- This version of the adapters has been certified with #{partner_sdk_name} #{partner_version}.\n\n###")
   write_changelog(changelog)
-  puts "added"
 end

--- a/Scripts/common.rb
+++ b/Scripts/common.rb
@@ -3,20 +3,35 @@
 PODSPEC_PATH_PATTERN = "*.podspec"
 PODSPEC_VERSION_REGEX = /^\s*spec\.version\s*=\s*'([0-9]+.[0-9]+.[0-9]+.[0-9]+.[0-9]+(?>.[0-9]+)?)'\s*$/
 PODSPEC_NAME_REGEX = /^\s*spec\.name\s*=\s*'([^']+)'\s*$/
-PODSPEC_PARTNER_AND_VERSION_REGEX = /spec\.dependency\s*'([^']+)',\s*'([\.0-9]+)'\s*$/
+PODSPEC_PARTNER_REGEX = /spec\.dependency\s*'([^']+)'/
 CHANGELOG_PATH = "CHANGELOG.md"
+ADAPTER_CLASS_PREFIX = "ChartboostMediationAdapter"
+ADAPTER_VERSION_REGEX = /^\s*let adapterVersion\s*=\s*"([^"]+)".*$/
+
+###########
+# PODSPEC #
+###########
 
 # Returns the podspec contents as a string.
 def read_podspec
-  # Obtain the podspec file path
-  file = Dir.glob(PODSPEC_PATH_PATTERN).first
-  fail unless !file.nil?
-
-  # Read the contents
-  text = File.read(file)
+  # Read the podspec contents
+  text = File.read(podspec_file_path)
+  fail unless !text.nil?
 
   # Return value
   text
+end
+
+# Writes a string to the podspec file.
+def write_podspec(text)
+  File.open(podspec_file_path, "w") { |file| file.puts text }
+end
+
+# The path to the podspec file.
+def podspec_file_path
+  path = Dir.glob(PODSPEC_PATH_PATTERN).first
+  fail unless !path.nil?
+  path
 end
 
 # Returns the podspec version value.
@@ -45,18 +60,22 @@ def podspec_name
   name
 end
 
-# Returns the podspec partner SDK name and partner version values.
-def podspec_partner_sdk_name_and_version
+# Returns the podspec partner SDK dependency name.
+def podspec_partner_sdk_name
   # Obtain the podspec
   text = read_podspec()
 
-  # Obtain the partner SDK name and partner version from the podspec
-  partner_sdk, partner_version = text.scan(PODSPEC_PARTNER_AND_VERSION_REGEX).last
-  fail unless !partner_sdk.nil? && !partner_version.nil?
+  # Obtain the partner SDK name from the podspec
+  partner_sdk = text.scan(PODSPEC_PARTNER_REGEX).last.first
+  fail unless !partner_sdk.nil?
 
-  # Return values
-  return partner_sdk, partner_version
+  # Return value
+  return partner_sdk
 end
+
+#############
+# CHANGELOG #
+#############
 
 # Returns the changelog contents as a string.
 def read_changelog
@@ -71,4 +90,36 @@ end
 # Writes a string to the changelog file.
 def write_changelog(text)
   File.open(CHANGELOG_PATH, "w") { |file| file.puts text }
+end
+
+#################
+# ADAPTER CLASS #
+#################
+
+# Returns the main adapter class contents as a string.
+def read_adapter_class
+  # Read the contents
+  text = File.read(adapter_class_file_path)
+  fail unless !text.nil?
+
+  # Return value
+  text
+end
+
+# Writes a string to the main adapter class file.
+def write_adapter_class(text)
+  File.open(adapter_class_file_path, "w") { |file| file.puts text }
+end
+
+# The path to the main adapter class file.
+def adapter_class_file_path
+  # Obtain the partner name
+  partner_name = podspec_name.delete_prefix ADAPTER_CLASS_PREFIX
+
+  # Obtain the Adapter file path
+  path = Dir.glob("./Source/#{partner_name}Adapter.swift").first
+  fail unless !path.nil?
+
+  # Return value
+  path
 end

--- a/Scripts/update_adapter_class_version.rb
+++ b/Scripts/update_adapter_class_version.rb
@@ -1,0 +1,16 @@
+# Updates the main PartnerAdapter class by replacing the adapter version string.
+
+require_relative 'common'
+
+# Parse the new version string from the arguments
+abort "Missing argument. Requires: version string." unless ARGV.count == 1
+new_version = ARGV[0]
+
+# Read the main adapter class file
+adapter_class = read_adapter_class()
+
+# Replace the partner adapter version
+adapter_class = adapter_class.sub(ADAPTER_VERSION_REGEX, "    let adapterVersion = \"#{new_version}\"")
+
+# Write the changes
+write_adapter_class(adapter_class)

--- a/Scripts/update_podspec_versions.rb
+++ b/Scripts/update_podspec_versions.rb
@@ -1,0 +1,23 @@
+# Updates the podspec by replacing the adapter and partner versions.
+
+require_relative 'common'
+
+# Parse the version strings from the arguments
+abort "Missing argument. Requires: adapter version string, partner version string." unless ARGV.count == 2
+adapter_version = ARGV[0]
+partner_version = ARGV[1]
+
+# Obtain the partner SDK name from the podspec
+partner_sdk_name = podspec_partner_sdk_name()
+
+# Read the podspec file
+podspec = read_podspec()
+
+# Replace the adapter version string in the podspec
+podspec = podspec.sub(PODSPEC_VERSION_REGEX, "  spec.version     = '#{adapter_version}'")
+
+# Replace the partner SDK version string in the podspec
+podspec = podspec.sub(/spec\.dependency\s*'#{partner_sdk_name}'.*$/, "spec.dependency '#{partner_sdk_name}', '#{partner_version}'")
+
+# Write the changes
+write_podspec(podspec)

--- a/Scripts/validate-adapter-and-partner-versions.rb
+++ b/Scripts/validate-adapter-and-partner-versions.rb
@@ -1,0 +1,15 @@
+# Validates that an adapter and partner version strings match.
+
+# Parse the version strings from the arguments
+abort "Missing argument. Requires: adapter version string, partner version string." unless ARGV.count == 2
+adapter_version = ARGV[0]
+partner_version = ARGV[1]
+
+# Strip the Chartboost Mediation SDK digit and the adapter build digits
+partner_digits_in_adapter_version = adapter_version.split('.')[1...-1].join('.')
+
+# Strip the cocoapods optimistic operation from the partner version if it exists
+partner_version = partner_version.delete_prefix('~> ')
+
+# Output match result
+puts partner_digits_in_adapter_version == partner_version

--- a/Scripts/validate-adapter-version.rb
+++ b/Scripts/validate-adapter-version.rb
@@ -1,16 +1,7 @@
 require_relative 'common'
 
-ADAPTER_VERSION_REGEX = /^\s*let adapterVersion\s*=\s*"([^"]+)".*$/
-
-# Obtain the partner name
-partner_name = podspec_name().delete_prefix "ChartboostMediationAdapter"
-
-# Obtain the Adapter file path
-file = Dir.glob("./Source/#{partner_name}Adapter.swift").first
-fail unless !file.nil?
-
 # Obtain the adapter version from the Adapter file
-text = File.read(file)
+text = read_adapter_class()
 adapter_version = text.match(ADAPTER_VERSION_REGEX).captures.first
 fail unless !adapter_version.nil?
 

--- a/Scripts/validate-new-release-version.rb
+++ b/Scripts/validate-new-release-version.rb
@@ -1,0 +1,22 @@
+# Validates an adapter version string, checking it is well-formed and that it hasn't been released yet.
+
+# Parse the new version string from the arguments
+abort "Missing argument. Requires: version string." unless ARGV.count == 1
+new_version = ARGV[0]
+
+# Check that the version is 5 or 6 digits long
+new_version_components = new_version.split('.')
+if new_version_components.count < 5 || new_version_components.count > 6
+  puts false
+  exit 0
+end
+
+# Check if a tag for that version already exists in the remote
+# This command:
+# 1. Fetches all tags from origin
+# 2. Lists all tags that match the new version string
+# 3. Returns the new version string if the corresponding tag was found, empty string otherwise
+version_tag_check = %x( git fetch origin --tags --prune --prune-tags --force && git tag -l "#{new_version}" | head -1)
+
+# Output result to console: success if tag not found, failure otherwise.
+puts version_tag_check.empty?


### PR DESCRIPTION
Implemented new workflow based on Kendall's improvements document.

I validated by force-pushing the workflow to the main branch on the reference adapter, and running it multiple times to reproduce success and failure paths for all steps.

Results for a successful path creating a 4.2.0.0.0 branch for partner 2.0.0 based off the main branch:
<img width="1044" alt="Screen Shot 2023-03-23 at 7 48 07 PM" src="https://user-images.githubusercontent.com/9442254/227320546-17ddb9dd-524d-42d1-880f-9b9674fdf2c4.png">
<img width="1016" alt="Screen Shot 2023-03-23 at 7 48 12 PM" src="https://user-images.githubusercontent.com/9442254/227320556-841bd75b-8c28-4149-8b76-fde01dbf1e3b.png">
<img width="1014" alt="Screen Shot 2023-03-23 at 7 48 17 PM" src="https://user-images.githubusercontent.com/9442254/227320563-e44cad4d-033c-4ab1-a426-44e2eebe05ee.png">


Testing the use of a tag as the base branch was a bit more difficult, since that tag version must contain the new scripts (drawbacks of not having all this as centralized actions yet).
I tested this path by pushing a test tag on main, creating a new branch off main and pushing some random changes, then running the workflow from that branch but selecting that tag:
<img width="444" alt="Screen Shot 2023-03-23 at 7 53 39 PM" src="https://user-images.githubusercontent.com/9442254/227321037-68668731-70d6-48fe-9b11-4abc97a17434.png">
As you can see the new `release/4.2.1.0.0 branch` was based off the tag and not the `test-branch33` branch used to run the workflow:
<img width="936" alt="Screen Shot 2023-03-23 at 7 55 09 PM" src="https://user-images.githubusercontent.com/9442254/227321241-6b974758-e0c9-462f-bb4e-dc27eb67e66b.png">

