### PR TITLE
HB-6484: consistent URL init result

### DIFF
--- a/Source/ReferenceSdk/ReferenceBannerAd.swift
+++ b/Source/ReferenceSdk/ReferenceBannerAd.swift
@@ -74,7 +74,7 @@ class ReferenceBannerAd: UIView {
         let bannerAd = WKWebView()
         addSubview(bannerAd)
         bannerAd.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        bannerAd.load(URLRequest(url: URL(string: size.rawValue)!))
+        bannerAd.load(URLRequest(url: URL(unsafeString: size.rawValue)!))
         
         // Create another view and place it on top the webview so it recognizes tap events
         let tapAreaOverlay = UIView(frame: bounds)
@@ -100,7 +100,7 @@ class ReferenceBannerAd: UIView {
     /// Perform a clickthrough to a predetermined landing page.
     @objc func clickthrough() {
         /// Show the ad as a webpage via an SFSafariViewController
-        guard let url = URL(string: clickThroughUrl) else {
+        guard let url = URL(unsafeString: clickThroughUrl) else {
             if #available(iOS 12.0, *) {
                 os_log(.error, log: log, "Failed to perform clickthrough action due to invalid destination URL.")
             }

--- a/Source/ReferenceSdk/ReferenceFullscreenAd.swift
+++ b/Source/ReferenceSdk/ReferenceFullscreenAd.swift
@@ -55,7 +55,7 @@ class ReferenceFullscreenAd: NSObject {
     /// Attempt to show the currently loaded fullscreen ad.
     func show() {
         /// Show the ad as a webpage via an SFSafariViewController
-        guard let url = URL(string: fullscreenAdFormat.rawValue) else {
+        guard let url = URL(unsafeString: fullscreenAdFormat.rawValue) else {
             if #available(iOS 12.0, *) {
                 os_log(.error, log: log, "Failed to show fullscreen ad due to invalid creative URL.")
             }

--- a/Source/ReferenceSdk/URL+Reference.swift
+++ b/Source/ReferenceSdk/URL+Reference.swift
@@ -1,0 +1,20 @@
+// Copyright 2022-2023 Chartboost, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+import Foundation
+
+extension URL {
+    /// A failable init to avoid encoding invalid `unsafeString` characters in the `URL`.
+    /// - Parameter unsafeString: An unsanitized string that potentially contains invalid characters for representing a URL.
+    init?(unsafeString: String) {
+        if #available(iOS 17.0, *) {
+            // On iOS 17+, `URL(string:)` assumes `encodingInvalidCharacters` being `true`, which is
+            // inconsistent with older iOS versions and makes bad URL less obvious.
+            self.init(string: unsafeString, encodingInvalidCharacters: false)
+        } else {
+            self.init(string: unsafeString)
+        }
+    }
+}


### PR DESCRIPTION
On iOS 17+, `URL(string:)` assumes `encodingInvalidCharacters` being `true`, which is inconsistent with older iOS versions and makes bad URL less obvious. This PR introduces `URL.make(string:)` to keep the return value consistent before and after iOS 17.