### PR TITLE
Add option to enable auto-dismiss of fullscreen ads

### DIFF
--- a/Source/ReferenceAdapterConfiguration.swift
+++ b/Source/ReferenceAdapterConfiguration.swift
@@ -49,5 +49,19 @@ import os.log
         }
     }
 
+    /// Flag that can optionally be set to indicate the time interval to wait before auto-dismissing shown ads.
+    /// Auto-dismiss is disabled if the value is `nil`, which is the default.
+    public static var autoDismissFullscreenAdsDelay: TimeInterval? {
+        get {
+            ReferenceFullscreenAd.autoDismissAdsDelay
+        }
+        set {
+            ReferenceFullscreenAd.autoDismissAdsDelay = newValue
+            if #available(iOS 12.0, *) {
+                os_log(.debug, log: log, "Reference SDK auto-dismiss fullscreen ads delay set to %{public}s", "\(newValue?.description ?? "nil")")
+            }
+        }
+    }
+
     /// Append any other properties that publishers can configure.
 }


### PR DESCRIPTION
This option comes very handy in tests where we show and dismiss ads.
At this moment I need it to perform SDK memory leak tests.