### PR TITLE
Add workflow to create a release branch from an automated script

### DIFF
--- a/.github/workflows/automated-create-release-branch.yml
+++ b/.github/workflows/automated-create-release-branch.yml
@@ -1,0 +1,19 @@
+name: Automated Create Release Branch
+
+on:
+  # Automated trigger from a job running on an external repo
+  repository_dispatch:
+    types:
+      - automated-create-release-branch
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUBSERVICETOKEN }}
+
+jobs:
+  create-release-branch:
+    runs-on: macos-latest
+    steps:
+      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v1
+        with:
+          adapter-version: ${{ github.event.client_payload.adapter-version }}
+          partner-version: ${{ github.event.client_payload.partner-version }}


### PR DESCRIPTION
Added new workflow that mimics the existing `create-release-branch` workflow, but intended to be triggered from another repo instead of manually.

This is part of the epic https://chartboost.atlassian.net/browse/HB-5919.
I'd like to get this one merged early so I can do some tests. For now I'm applying it to the reference adapter only, I will open PRs for other adapters once everything is ready for review.