### PR TITLE
Bump min os version to match the value in the Mediation SDK podspec

### DIFF
--- a/ChartboostMediationAdapterReference.podspec
+++ b/ChartboostMediationAdapterReference.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |spec|
 
   # Minimum supported versions
   spec.swift_version         = '5.0'
-  spec.ios.deployment_target = '10.0'
+  spec.ios.deployment_target = '11.0'
 
   # System frameworks used
   spec.ios.frameworks = ['Foundation', 'SafariServices', 'UIKit', 'WebKit']

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Chartboost Mediation Reference adapter showcases the integration with the AP
 | ------ | ------ |
 | Chartboost Mediation SDK | 4.0.0+ |
 | Cocoapods | 1.11.3+ |
-| iOS | 10.0+ |
+| iOS | 11.0+ |
 | Xcode | 14.1+ |
 
 ## Integration


### PR DESCRIPTION
Match new Mediation SDK podspec value.
This helps with podfiles like the memory leaks test one which, unlike the Canary podfile, doesn't have a post-process step to fix the deployment target of all pod dependencies.