### PR TITLE
HB-7647: Configuration class rework

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -25,7 +25,7 @@ jobs:
   create-release-branch:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v2
         with:
           adapter-version: ${{ inputs.adapter-version || github.event.client_payload.adapter-version }}
           partner-version: ${{ inputs.partner-version || github.event.client_payload.partner-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,4 +12,4 @@ jobs:
   release-adapter:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v2

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,4 +12,4 @@ jobs:
   validate-podspec:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v2

--- a/Source/ReferenceAdapter.swift
+++ b/Source/ReferenceAdapter.swift
@@ -14,18 +14,26 @@ import UIKit
 final class ReferenceAdapter: PartnerAdapter {
     
     /// The version of the partner SDK.
-    let partnerSDKVersion = ReferenceSdk.getVersion()
-    
+    var partnerSDKVersion: String {
+        ReferenceAdapterConfiguration.partnerSDKVersion
+    }
+
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.1.0.0.2"
-    
+    var adapterVersion: String {
+        ReferenceAdapterConfiguration.adapterVersion
+    }
+
     /// The partner's unique identifier.
-    let partnerID = "reference"
-    
+    var partnerID: String {
+        ReferenceAdapterConfiguration.partnerID
+    }
+
     /// The human-friendly partner name.
-    let partnerDisplayName = "Reference"
+    var partnerDisplayName: String {
+        ReferenceAdapterConfiguration.partnerDisplayName
+    }
 
     /// Ad storage managed by Chartboost Mediation SDK.
     let storage: PartnerAdapterStorage

--- a/Source/ReferenceAdapterConfiguration.swift
+++ b/Source/ReferenceAdapterConfiguration.swift
@@ -11,6 +11,22 @@ import os.log
 /// A list of externally configurable properties pertaining to the partner SDK that can be retrieved and set by publishers.
 @objc public class ReferenceAdapterConfiguration: NSObject {
     
+    /// The version of the partner SDK.
+    @objc static var partnerSDKVersion: String {
+        ReferenceSdk.getVersion()
+    }
+
+    /// The version of the adapter.
+    /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
+    /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
+    @objc static let adapterVersion = "4.1.0.0.2"
+
+    /// The partner's unique identifier.
+    @objc static let partnerID = "reference"
+
+    /// The human-friendly partner name.
+    @objc static let partnerDisplayName = "Reference"
+
     private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.reference", category: "Configuration")
 
     /// Flag that can optionally be set to enable the partner's test mode.

--- a/Source/ReferenceAdapterConfiguration.swift
+++ b/Source/ReferenceAdapterConfiguration.swift
@@ -12,20 +12,20 @@ import os.log
 @objc public class ReferenceAdapterConfiguration: NSObject {
     
     /// The version of the partner SDK.
-    @objc static var partnerSDKVersion: String {
+    @objc public static var partnerSDKVersion: String {
         ReferenceSdk.getVersion()
     }
 
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc static let adapterVersion = "4.1.0.0.2"
+    @objc public static let adapterVersion = "4.1.0.0.2"
 
     /// The partner's unique identifier.
-    @objc static let partnerID = "reference"
+    @objc public static let partnerID = "reference"
 
     /// The human-friendly partner name.
-    @objc static let partnerDisplayName = "Reference"
+    @objc public static let partnerDisplayName = "Reference"
 
     private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.reference", category: "Configuration")
 


### PR DESCRIPTION
Move module property definitions to the public Configuration class to expose them to pubs and Unity. Add missing configuration options for parity with Android.